### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # k2catalogue
-[![Build Status](https://travis-ci.org/mindriot101/k2catalogue.svg)](https://travis-ci.org/mindriot101/k2catalogue)[![Code Health](https://landscape.io/github/mindriot101/k2catalogue/master/landscape.svg)](https://landscape.io/github/mindriot101/k2catalogue/master)[![Documentation Status](https://readthedocs.org/projects/k2catalogue/badge/?version=latest)](https://readthedocs.org/projects/k2catalogue/?badge=latest)[![Latest Version](https://pypip.in/version/k2catalogue/badge.svg)](https://pypi.python.org/pypi/k2catalogue/)
+[![Build Status](https://travis-ci.org/mindriot101/k2catalogue.svg)](https://travis-ci.org/mindriot101/k2catalogue)[![Code Health](https://landscape.io/github/mindriot101/k2catalogue/master/landscape.svg)](https://landscape.io/github/mindriot101/k2catalogue/master)[![Documentation Status](https://readthedocs.org/projects/k2catalogue/badge/?version=latest)](https://readthedocs.org/projects/k2catalogue/?badge=latest)[![Latest Version](https://img.shields.io/pypi/v/k2catalogue.svg)](https://pypi.python.org/pypi/k2catalogue/)
 
 Simple interactive query api for the K2 proposals list, based on the IPython console.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20k2catalogue))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `k2catalogue`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.